### PR TITLE
Parse arrays

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -2,8 +2,6 @@ package partialmarshal
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 )
@@ -16,151 +14,83 @@ import (
 // unmatching data into the embedded Extra map.
 //
 func Unmarshal(data []byte, v interface{}) error {
-
-	// 1. Unmarshal / Decode JSON strings using the stdlib decoder.
-
-	err := json.Unmarshal(data, v)
+	// 1. Check for a valid pointer to value of kind struct.
+	reflectedValue, err := getReflectedValue(v)
 	if err != nil {
 		return err
 	}
 
-	// 2. Identify whether the destination struct
-	// contains an "Extra" substruct
-
-	err = checkHasExtra(v)
+	// 2. Create the json.RawMessage map of this JSON object
+	var rawMap map[string]json.RawMessage
+	err = json.Unmarshal(data, &rawMap)
 	if err != nil {
 		return err
 	}
 
-	// 3. Filter the JSON payload for fields which do not match
-	// the fields of the destination struct.
-	// (requires use of the reflect package)
-
-	extraPayload, err := getExtraPayload(data, v)
+	// 3. Decode matching data into the struct and recursively call for substructs
+	err = decodeMatching(rawMap, reflectedValue)
 	if err != nil {
-		// This should never execute, but for the sake of
-		// completeness, getExtraPayload returns an error.
 		return err
 	}
 
-	// 4. Set the extra payload map to be the value of the
-	// Extra field in the struct.
-
-	extraField := reflect.Indirect(reflect.ValueOf(v)).FieldByName("Extra")
-	extraField.Set(reflect.ValueOf(extraPayload))
-
-	// 5. Do recursive partial unmarshaling of substructs
-	recursePartialUnmarshalForSubstructs(data, v)
+	// 4. Put Extra values into the Extra nested struct
+	extraField := reflectedValue.FieldByName("Extra")
+	if extraField.IsValid() {
+		extraField.Set(reflect.ValueOf(rawMap))
+	}
 
 	return nil
 }
 
-func recursePartialUnmarshalForSubstructs(data []byte, v interface{}) error {
-	// Get the struct type of the v interface{}
-
-	parent := reflect.Indirect(reflect.ValueOf(v))
-	if parent.Kind() != reflect.Struct {
-		return errors.New("value must be of type struct")
-	}
-
-	// Convert the data into a map of raw JSON messages
-	var rawMessageMap map[string]json.RawMessage
-	err := json.Unmarshal(data, &rawMessageMap)
-	if err != nil {
-		return err
-	}
-
-	// Loop over the given struct by fields
-	for i := 0; i < parent.Type().NumField(); i++ {
-		field := parent.Type().Field(i)
-
-		// Whenever we encounter a struct kind field
-		if field.Type.Kind() == reflect.Struct {
-
-			// Create a temporary storage variable of the same type as the child struct
-			temporaryChild := reflect.New(field.Type).Interface()
-
-			// Determine which raw data is associated with this child struct
-			var matchingRawData json.RawMessage
-			for key := range rawMessageMap {
-
-				// Directly by name
-				if key == field.Name {
-					matchingRawData = rawMessageMap[key]
-				}
-
-				// By JSON tags
-				tags := strings.Split(field.Tag.Get("json"), ",")
-				for _, tag := range tags {
-					if tag == key {
-						matchingRawData = rawMessageMap[key]
-					}
-				}
+func popValueByField(rawMap map[string]json.RawMessage, field reflect.StructField) (json.RawMessage, bool) {
+	rawValue, found := rawMap[field.Name]
+	if !found {
+		// Attempt match by JSON tags.
+		tags := strings.Split(field.Tag.Get("json"), ",")
+		for _, tag := range tags {
+			rawValue, found = rawMap[tag]
+			if found {
+				delete(rawMap, tag)
+				break
 			}
+		}
 
-			// Recursively run partialmarshal unmarshaling on the associated raw JSON
-			err = Unmarshal(matchingRawData, temporaryChild)
+		if !found {
+			// Still no match found, continue to next struct field
+			return rawValue, false
+		}
+	} else {
+		delete(rawMap, field.Name)
+	}
+	return rawValue, true
+}
+
+func decodeMatching(rawMap map[string]json.RawMessage, reflectedValue reflect.Value) error {
+	for i := 0; i < reflectedValue.Type().NumField(); i++ {
+		field := reflectedValue.Type().Field(i)
+		// Attempt match by field.Name
+		rawValue, found := popValueByField(rawMap, field)
+		if !found {
+			continue
+		}
+
+		temp := reflect.New(field.Type).Interface()
+
+		if field.Type.Kind() == reflect.Struct {
+			err := Unmarshal(rawValue, temp)
 			if err != nil {
 				return err
 			}
-
-			// Set the recursively unmarshaled child struct to the value of the field in the parent
-			actualStruct := reflect.Indirect(reflect.ValueOf(temporaryChild))
-			parent.FieldByName(field.Name).Set(actualStruct)
-		}
-	}
-
-	return nil
-}
-
-// getExtraPayload searches the provided JSON data for keys that do not match
-// fields of the provided valud v.
-// Any unmatching keys are put into a map with their respective values for return.
-func getExtraPayload(data []byte, v interface{}) (map[string]interface{}, error) {
-	var resultMap map[string]interface{}
-	err := json.Unmarshal(data, &resultMap)
-	if err != nil {
-		return resultMap, err
-	}
-
-	for key := range resultMap {
-		if hasFieldInStruct(v, key) {
-			delete(resultMap, key)
-		}
-	}
-
-	return resultMap, nil
-}
-
-// hasFieldInStruct returns true if a field matching a given key exists in the value v
-// and false if there is no field matching the provided key.
-func hasFieldInStruct(v interface{}, fieldKey string) bool {
-	return checkHasFieldInStruct(v, fieldKey) == nil
-}
-
-// checkHasFieldInStruct returns an error if the value v is not a struct/struct pointer,
-// or if there is no field in the value v that matches the provided key.
-func checkHasFieldInStruct(v interface{}, fieldKey string) error {
-
-	value := reflect.Indirect(reflect.ValueOf(v))
-
-	if value.Kind() != reflect.Struct {
-		return errors.New("value must be of type struct")
-	}
-	for i := 0; i < value.Type().NumField(); i++ {
-		field := value.Type().Field(i)
-
-		if strings.ToLower(field.Name) == fieldKey || field.Name == fieldKey {
-			return nil
-		}
-
-		tags := strings.Split(field.Tag.Get("json"), ",")
-		for _, tag := range tags {
-			if tag == fieldKey {
-				return nil
+		} else {
+			err := json.Unmarshal(rawValue, &temp)
+			if err != nil {
+				return err
 			}
 		}
-	}
 
-	return fmt.Errorf("could not find field %s in struct", fieldKey)
+		actualValue := reflect.Indirect(reflect.ValueOf(temp))
+		reflectedValue.FieldByName(field.Name).Set(actualValue)
+
+	}
+	return nil
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -78,6 +78,163 @@ func TestUnmarshal(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"should unmarshal extra payload into extra field of substruct",
+			[]byte(`{"field_one": "value one", "FieldSubStruct": {"sub_field_one": "sub value one", "sub_field_two": "sub value two"}, "field_two": "value two"}`),
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}
+				Extra
+			}{},
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}
+				Extra
+			}{
+				"value one",
+				struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}{
+					"sub value one",
+					map[string]interface{}{
+						"sub_field_two": "sub value two",
+					},
+				},
+				map[string]interface{}{
+					"field_two": "value two",
+				},
+			},
+			"",
+		},
+		{
+			"should unmarshal extra payload into extra field of substruct with matching json tags",
+			[]byte(`{"field_one": "value one", "FieldSubStruct": {"sub_field_one": "sub value one", "sub_field_two": "sub value two"}, "field_two": "value two"}`),
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}
+				Extra
+			}{},
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}
+				Extra
+			}{
+				"value one",
+				struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}{
+					"sub value one",
+					map[string]interface{}{
+						"sub_field_two": "sub value two",
+					},
+				},
+				map[string]interface{}{
+					"field_two": "value two",
+				},
+			},
+			"",
+		},
+		{
+			"should unmarshal extra payload into extra field of substruct with matching substruct json tags",
+			[]byte(`{"field_one": "value one", "field_sub_struct": {"sub_field_one": "sub value one", "sub_field_two": "sub value two"}, "field_two": "value two"}`),
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				} `json:"field_sub_struct"`
+				Extra
+			}{},
+			&struct {
+				FieldOne       string `json:"field_one"`
+				FieldSubStruct struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				} `json:"field_sub_struct"`
+				Extra
+			}{
+				"value one",
+				struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}{
+					"sub value one",
+					map[string]interface{}{
+						"sub_field_two": "sub value two",
+					},
+				},
+				map[string]interface{}{
+					"field_two": "value two",
+				},
+			},
+			"",
+		},
+		{
+			"should unmarshal extra payload into extra field of multiple substructs with matching substruct json tags",
+			[]byte(`{"field_one": "value one", "field_sub_struct_one": {"sub_field_one": "sub value one", "sub_field_two": "sub value two"}, "field_sub_struct_two": {"sub_field_three": "sub value three", "sub_field_four": "sub value four"}, "field_two": "value two"}`),
+			&struct {
+				FieldOne          string `json:"field_one"`
+				FieldSubStructOne struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				} `json:"field_sub_struct_one"`
+				FieldSubStructTwo struct {
+					SubFieldThree string `json:"sub_field_three"`
+					Extra
+				} `json:"field_sub_struct_two"`
+				Extra
+			}{},
+			&struct {
+				FieldOne          string `json:"field_one"`
+				FieldSubStructOne struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				} `json:"field_sub_struct_one"`
+				FieldSubStructTwo struct {
+					SubFieldThree string `json:"sub_field_three"`
+					Extra
+				} `json:"field_sub_struct_two"`
+				Extra
+			}{
+				"value one",
+				struct {
+					SubFieldOne string `json:"sub_field_one"`
+					Extra
+				}{
+					"sub value one",
+					map[string]interface{}{
+						"sub_field_two": "sub value two",
+					},
+				},
+				struct {
+					SubFieldThree string `json:"sub_field_three"`
+					Extra
+				}{
+					"sub value three",
+					map[string]interface{}{
+						"sub_field_four": "sub value four",
+					},
+				},
+				map[string]interface{}{
+					"field_two": "value two",
+				},
+			},
+			"",
+		},
 		// Sad Path Cases
 		{
 			"should return error when provided value not struct pointer",

--- a/encode.go
+++ b/encode.go
@@ -3,6 +3,7 @@ package partialmarshal
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/fatih/structs"
 )
@@ -14,28 +15,69 @@ import (
 // places the extra payload into the JSON output as top-level key/value pairs.
 func Marshal(v interface{}) ([]byte, error) {
 	// 1. Detect and retrieve the partialmarshal.Extra embedded type
-
-	err := checkHasExtra(v)
-	if err != nil {
-		return nil, err
+	reflectedValue := reflect.Indirect(reflect.ValueOf(v))
+	if reflectedValue.Kind() != reflect.Struct {
+		return json.Marshal(v)
 	}
 
-	extraField := reflect.Indirect(reflect.ValueOf(v)).FieldByName("Extra")
+	extraField := reflectedValue.FieldByName("Extra")
+	if !extraField.IsValid() {
+		return json.Marshal(v)
+	}
 
-	// 2. Convert the value v into a map[string]interface{}
+	// 2. Handle any substructs that may or may not have partialmarshal.Extra fields present
+	substructsMap, substructsTagMap := getSubstructsWithExtra(reflectedValue)
 
+	// 3. Convert the value v into a map[string]interface{}
 	// https://github.com/fatih/structs/issues/25
 	structs.DefaultTagName = "json"
 	valueAsMap := structs.Map(v)
 	delete(valueAsMap, "Extra")
 
-	// 3. Combine the map[string]interface{} v clone with the extra map
+	// 4. Add any found substructs into the map
+	for key, value := range substructsMap {
+		jsonTag, found := substructsTagMap[key]
+		if found {
+			valueAsMap[jsonTag] = value
+			delete(valueAsMap, key)
+		} else {
+			valueAsMap[key] = value
+		}
+	}
 
+	// 5. Combine the map[string]interface{} v clone with the extra map
 	extraFieldAsMap := extraField.Interface().(Extra)
 	for key, value := range extraFieldAsMap {
 		valueAsMap[key] = value
 	}
 
-	// 4. Encode the combined map into a JSON output
+	// 6. Encode the combined map into a JSON output
 	return json.Marshal(valueAsMap)
+}
+
+func getSubstructsWithExtra(reflectedValue reflect.Value) (map[string]json.RawMessage, map[string]string) {
+
+	substructsMap := map[string]json.RawMessage{}
+	substructsTagMap := map[string]string{}
+
+	for i := 0; i < reflectedValue.Type().NumField(); i++ {
+		structField := reflectedValue.Type().Field(i)
+		field := reflectedValue.Field(i)
+		if field.Type().Kind() == reflect.Struct {
+			encodedStruct, _ := Marshal(field.Interface())
+			jsonTag, _ := parseTag(string(structField.Tag.Get("json")))
+			if jsonTag != "" {
+				substructsTagMap[structField.Name] = jsonTag
+			}
+			substructsMap[structField.Name] = encodedStruct
+		}
+	}
+	return substructsMap, substructsTagMap
+}
+
+func parseTag(tag string) (string, string) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tag[idx+1:]
+	}
+	return tag, ""
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -55,6 +55,28 @@ func TestMarshal(t *testing.T) {
 			"",
 		},
 		{
+			"should marshal extra field into top-level keys in array payload from slice pointer",
+			&[]struct {
+				FieldOne string
+				Extra
+			}{
+				{
+					"value one",
+					Extra{
+						"field_two": []byte(`"value two"`),
+					},
+				},
+				{
+					"second value one",
+					Extra{
+						"field_two": []byte(`"second value two"`),
+					},
+				},
+			},
+			[]byte(`[{"FieldOne":"value one","field_two":"value two"},{"FieldOne":"second value one","field_two":"second value two"}]`),
+			"",
+		},
+		{
 			"should marshal extra field into top-level keys in payload from non-pointer struct",
 			struct {
 				FieldOne string


### PR DESCRIPTION
Based on top of #8, so includes those changes also.

# Changelog:
## Decode
- `Unmarshal()` now muxes between `unmarshalArray()` and `unmarshalObject()`
- `unmarshalArray` checks v for slice type and runs `unmarshalObject` on the list of JSON values in the array.
- Added integration tests for unmarshaling JSON with arrays.
## Encode
- `Marshal()` now muxes between `marshalArray()` and `marshalObject()`
- `marshalArray` runs `marshalObject` on the slice and appends each serialized format into a slice of `json.RawMessage` objects. Then marshals the slice of `json.RawMessage` objects to finish up.
- Added integration tests for marshaling slices of objects.